### PR TITLE
Task 7 Authorization

### DIFF
--- a/import-service/serverless.yml
+++ b/import-service/serverless.yml
@@ -28,7 +28,11 @@ functions:
       - http:
           path: import
           method: get
-          cors: true
+          cors:
+            origin: '*'
+          authorizer:
+            arn: arn:aws:lambda:us-east-1:975555951614:function:authorization-service-dev-basicAuthorizer
+            type: token
           request:
             parameters:
               querystrings:
@@ -49,3 +53,12 @@ resources:
       Type: AWS::SQS::Queue
       Properties:
         QueueName: catalogItemsQueue
+    Unauthorized:
+      Type: AWS::ApiGateway::GatewayResponse
+      Properties:
+        ResponseParameters:
+          "gatewayresponse.header.Access-Control-Allow-Origin": "'*'"
+          "gatewayresponse.header.Access-Control-Allow-Headers": "'*'"
+        ResponseType: "DEFAULT_4XX"
+        RestApiId:
+          Ref: "ApiGatewayRestApi"


### PR DESCRIPTION
CloudFront: https://d3kgw2jxpum300.cloudfront.net/
FE: https://github.com/Bordo951/shop-react-redux-cloudfront/pull/5 

**Task 7.1**
- [x] Authorization-service is added to the repo, has correct basicAuthorizer lambda and correct serverless.yaml file

**Task 7.2**
- [x] Import Service serverless.yaml file has authorizer configuration for the importProductsFile lambda. Request to the importProductsFile lambda should work only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response should be in 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided.

**Task 7.3**
- [x] Client application is updated to send "Authorization: Basic authorization_token" header on import. Client should get authorization_token value from browser localStorage

**Task 7.4**
- [x] Provide pull request for crosscheck

Additional task
- [x] (+30) Client application should display alerts for the responses in 401 and 403 HTTP statuses.


**Total score:** 100/100

![image](https://github.com/Bordo951/aws-training-BE/assets/68749060/ac532b41-743e-4d65-858e-b3f76c597d2c)
![image](https://github.com/Bordo951/aws-training-BE/assets/68749060/042fed4b-d92c-4b2d-be15-bbed42ffba68)

